### PR TITLE
JQuery ajax API change:  type -> method

### DIFF
--- a/addon/mixins/promise.js
+++ b/addon/mixins/promise.js
@@ -1,10 +1,10 @@
 import Ember from 'ember';
 
 var PromiseMixin = Ember.Object.create({
-    xhr: function(url, type, hash) {
+    xhr: function(url, method, hash) {
         hash = hash || {};
         hash.url = url;
-        hash.type = type || "GET";
+        hash.method = method || "GET";
         hash.dataType = "json";
         hash.cache = false;
         hash.contentType = "application/json";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-promise",
-  "version": "0.2.1",
+  "version": "0.3.0",
   "description": "A simple promise object that will wrap xhr resolve/reject with an ember.run",
   "directories": {
     "doc": "doc",


### PR DESCRIPTION
JQuery ajax changed the API in 1.9.0 to add the key of `method` in favor of `type` for the request method. `type` still exists but only as an alias for `method`.

I was attempting to use this addon in conjunction with @jarrodctaylor's fauxjax 1.0.2 and found that fauxjax was expecting the key of `method`. I am submitting a fix here because of the reason stated above.

Thanks!
