### PR TITLE
[ENHANCEMENT] adding hook to allow user defaults for AJAX requests

### DIFF
--- a/addon/mixins/promise.js
+++ b/addon/mixins/promise.js
@@ -22,16 +22,10 @@ var PromiseMixin = Ember.Object.create({
         });
     },
     configureAjaxDefaults: function(hash) {
-        if(!hash.method) {
-            hash.method = "GET";
-        }
-        if(hash.dataType === undefined) {
-            hash.dataType = "json";
-        }
-        if(hash.cache === undefined) {
-            hash.cache = false;
-        }
-        if(hash.contentType === undefined && hash.data) {
+        hash.method = hash.method || "GET";
+        hash.dataType = hash.dataType || "json";
+        hash.cache = hash.cache || false;
+        if(!hash.contentType && hash.data) {
             hash.contentType = "application/json";
         }
         return hash;

--- a/addon/mixins/promise.js
+++ b/addon/mixins/promise.js
@@ -5,10 +5,8 @@ var PromiseMixin = Ember.Object.create({
         var self = this;
         hash = hash || {};
         hash.url = url;
-        hash.method = method || "GET";
-        hash.dataType = "json";
-        hash.cache = false;
-        hash.contentType = "application/json";
+        hash.method = method;
+        hash = this.configureAjaxDefaults(hash);
         return new Ember.RSVP.Promise(function(resolve, reject) {
             hash.success = function(json) {
                 return Ember.run(null, resolve, json);
@@ -23,8 +21,22 @@ var PromiseMixin = Ember.Object.create({
             Ember.$.ajax(hash);
         });
     },
-    onError: function() {
-    }
+    configureAjaxDefaults: function(hash) {
+        if(!hash.method) {
+            hash.method = "GET";
+        }
+        if(hash.dataType === undefined) {
+            hash.dataType = "json";
+        }
+        if(hash.cache === undefined) {
+            hash.cache = false;
+        }
+        if(hash.contentType === undefined && hash.method !== "GET") {
+            hash.contentType = "application/json";
+        }
+        return hash;
+    },
+    onError: function() { }
 });
 
 export default PromiseMixin;

--- a/addon/mixins/promise.js
+++ b/addon/mixins/promise.js
@@ -31,7 +31,7 @@ var PromiseMixin = Ember.Object.create({
         if(hash.cache === undefined) {
             hash.cache = false;
         }
-        if(hash.contentType === undefined && hash.method !== "GET") {
+        if(hash.contentType === undefined && hash.data) {
             hash.contentType = "application/json";
         }
         return hash;

--- a/tests/unit/promise-unit-test.js
+++ b/tests/unit/promise-unit-test.js
@@ -12,25 +12,29 @@ test("Test default configuration for AJAX GET requests", function(assert) {
 });
 
 test("Test default configuration for AJAX Other requests", function(assert) {
-    var hash = PromiseMixin.configureAjaxDefaults({method: "OTHER"});
-    assert.equal(Object.keys(hash).length, 4);
-    assert.equal(hash.method, "OTHER");
+    var hash = PromiseMixin.configureAjaxDefaults({data: JSON.stringify({}), method: "POST"});
+    assert.equal(Object.keys(hash).length, 5);
+    assert.equal(hash.method, "POST");
     assert.equal(hash.dataType, "json");
     assert.equal(hash.cache, false);
     assert.equal(hash.contentType, "application/json");
+    assert.equal(hash.data, "{}");
 });
 
 test("Test default configuration respects values already set for AJAX requests", function(assert) {
+    var postData = {};
     var configuredHash = {
-        method: "OTHER",
+        data: postData,
+        method: "POST",
         dataType: "text",
         cache: true,
         contentType: "text/plain"
     };
     var hash = PromiseMixin.configureAjaxDefaults(configuredHash);
-    assert.equal(Object.keys(hash).length, 4);
-    assert.equal(hash.method, "OTHER");
+    assert.equal(Object.keys(hash).length, 5);
+    assert.equal(hash.method, "POST");
     assert.equal(hash.dataType, "text");
     assert.equal(hash.cache, true);
     assert.equal(hash.contentType, "text/plain");
+    assert.equal(hash.data, postData);
 });

--- a/tests/unit/promise-unit-test.js
+++ b/tests/unit/promise-unit-test.js
@@ -1,0 +1,36 @@
+import { test, module } from 'qunit';
+import PromiseMixin from "ember-promise/mixins/promise";
+
+module('PromiseMixin Unit Test');
+
+test("Test default configuration for AJAX GET requests", function(assert) {
+    var hash = PromiseMixin.configureAjaxDefaults({});
+    assert.equal(Object.keys(hash).length, 3);
+    assert.equal(hash.method, "GET");
+    assert.equal(hash.dataType, "json");
+    assert.equal(hash.cache, false);
+});
+
+test("Test default configuration for AJAX Other requests", function(assert) {
+    var hash = PromiseMixin.configureAjaxDefaults({method: "OTHER"});
+    assert.equal(Object.keys(hash).length, 4);
+    assert.equal(hash.method, "OTHER");
+    assert.equal(hash.dataType, "json");
+    assert.equal(hash.cache, false);
+    assert.equal(hash.contentType, "application/json");
+});
+
+test("Test default configuration respects values already set for AJAX requests", function(assert) {
+    var configuredHash = {
+        method: "OTHER",
+        dataType: "text",
+        cache: true,
+        contentType: "text/plain"
+    };
+    var hash = PromiseMixin.configureAjaxDefaults(configuredHash);
+    assert.equal(Object.keys(hash).length, 4);
+    assert.equal(hash.method, "OTHER");
+    assert.equal(hash.dataType, "text");
+    assert.equal(hash.cache, true);
+    assert.equal(hash.contentType, "text/plain");
+});


### PR DESCRIPTION
Also do not set the contentType to "application/json" when it is a GET
request as a body is not material to a GET request and therefore should
not need to specify a contentType.
